### PR TITLE
Add GitHub Skills activity to signup system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub - part of our GitHub Certifications program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Fix for Issue #6: Missing GitHub Skills Activity

This PR adds the missing **GitHub Skills** activity that was announced by the principal at the school assembly.

### 📋 Changes Made
- ✅ Added "GitHub Skills" to the activities dictionary in `app.py`
- ✅ Description mentions GitHub Certifications program (as referenced in the issue)
- ✅ Schedule: Wednesdays, 3:30 PM - 5:00 PM
- ✅ Max participants: 25 students (larger capacity for school-wide initiative)
- ✅ Ready for immediate student registration

### ⏱️ Urgency
This addresses the time-sensitive issue where students couldn't find the activity to register, with the deadline approaching at the end of this week.

### 🧪 Testing
The activity will now appear in the signup page alongside other activities like Chess Club, Programming Class, and Gym Class.

Fixes #6